### PR TITLE
fix top-level awaitの廃止

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -42,10 +42,10 @@
 🖼layout:
   - src/routes/**/+layout.svelte
   - src/app.css
-🐟➡:
+🐟serverScript:
   - src/routes/**/+page.server.ts
-  - src/libs/server/*
+  - src/lib/server/*
   - src/hooks.server.js
   - src/service-worker.js
-📱➡:
+📱clientScript:
   - src/hooks.client.js

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,7 @@ node_modules
 !.env.example
 *.md
 *.yml
+*.mjs
 
 # Ignore files for PNPM, NPM and YARN
 pnpm-lock.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,9 @@
 		"source.organizeImports": true, //保存時に import を整理する
 		"source.fixAll.eslint": true // 保村時に ESLint で修正する
 	},
+	"[svelte]": {
+		"editor.defaultFormatter": "svelte.svelte-vscode"
+	},
 	"[markdown]": {
 		"files.trimTrailingWhitespace": false // Markdown ファイルの末尾の空白を取り除く
 	},

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,0 @@
-1:
-	pnpm format
-	pnpm check
-	pnpm test:u
-	pnpm test:c
-	pnpm test:i

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+1:
+	pnpm format
+	pnpm check
+	pnpm test:u
+	pnpm test:c
+	pnpm test:i

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 		"format": "prettier --plugin-search-dir . --write .",
 		"test:u": "vitest run",
 		"test:c": "playwright test -c playwright-ct.config.ts",
-		"test:i": "playwright test -c playwright.config.ts"
+		"test:i": "playwright test -c playwright.config.ts",
+		"2": "pnpm format && pnpm lint & pnpm check & pnpm test:u & pnpm test:c & pnpm test:i"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.30.0",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
 		"tslib": "^2.5.0",
 		"typescript": "^4.9.5",
 		"vite": "^4.1.2",
-		"vitest": "^0.25.8"
+		"vitest": "^0.25.8",
+		"@playwright/experimental-ct-svelte": "^1.30.0"
 	},
 	"type": "module",
 	"dependencies": {
-		"@notionhq/client": "^2.2.3",
-		"@playwright/experimental-ct-svelte": "^1.30.0"
+		"@notionhq/client": "^2.2.3"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,9 +28,9 @@ specifiers:
 
 dependencies:
   '@notionhq/client': 2.2.3
-  '@playwright/experimental-ct-svelte': 1.30.0_svelte@3.55.1
 
 devDependencies:
+  '@playwright/experimental-ct-svelte': 1.30.0_svelte@3.55.1
   '@playwright/test': 1.30.0
   '@sveltejs/adapter-auto': 1.0.3_@sveltejs+kit@1.7.2
   '@sveltejs/adapter-cloudflare': 2.0.2_@sveltejs+kit@1.7.2
@@ -94,6 +94,7 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64/0.16.17:
@@ -102,6 +103,7 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64/0.16.17:
@@ -110,6 +112,7 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64/0.16.17:
@@ -118,6 +121,7 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64/0.16.17:
@@ -126,6 +130,7 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64/0.16.17:
@@ -134,6 +139,7 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64/0.16.17:
@@ -142,6 +148,7 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm/0.16.17:
@@ -150,6 +157,7 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64/0.16.17:
@@ -158,6 +166,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32/0.16.17:
@@ -166,6 +175,7 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64/0.16.17:
@@ -174,6 +184,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el/0.16.17:
@@ -182,6 +193,7 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64/0.16.17:
@@ -190,6 +202,7 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64/0.16.17:
@@ -198,6 +211,7 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x/0.16.17:
@@ -206,6 +220,7 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64/0.16.17:
@@ -214,6 +229,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64/0.16.17:
@@ -222,6 +238,7 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64/0.16.17:
@@ -230,6 +247,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/sunos-x64/0.16.17:
@@ -238,6 +256,7 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64/0.16.17:
@@ -246,6 +265,7 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32/0.16.17:
@@ -254,6 +274,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64/0.16.17:
@@ -262,6 +283,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: true
     optional: true
 
   /@eslint/eslintrc/1.4.1:
@@ -308,6 +330,7 @@ packages:
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
+    dev: true
 
   /@jridgewell/trace-mapping/0.3.17:
     resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
@@ -363,7 +386,7 @@ packages:
       - supports-color
       - svelte
       - terser
-    dev: false
+    dev: true
 
   /@playwright/test/1.30.0:
     resolution: {integrity: sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==}
@@ -372,6 +395,7 @@ packages:
     dependencies:
       '@types/node': 18.14.0
       playwright-core: 1.30.0
+    dev: true
 
   /@polka/url/1.0.0-next.21:
     resolution: {integrity: sha512-a5Sab1C4/icpTZVzZc5Ghpz88yQtGOyNqYXcZgOssB2uuAr+wF/MvN6bgtW32q7HHrvBki+BsZ0OuNv6EV3K9g==}
@@ -442,6 +466,7 @@ packages:
       vitefu: 0.2.4_vite@4.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@testing-library/dom/8.20.0:
     resolution: {integrity: sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==}
@@ -994,6 +1019,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
+    dev: true
 
   /decimal.js/10.4.3:
     resolution: {integrity: sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==}
@@ -1035,6 +1061,7 @@ packages:
   /deepmerge/4.3.0:
     resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /define-properties/1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
@@ -1159,6 +1186,7 @@ packages:
       '@esbuild/win32-arm64': 0.16.17
       '@esbuild/win32-ia32': 0.16.17
       '@esbuild/win32-x64': 0.16.17
+    dev: true
 
   /escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
@@ -1439,10 +1467,12 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
+    dev: true
     optional: true
 
   /function-bind/1.1.1:
     resolution: {integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==}
+    dev: true
 
   /functions-have-names/1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
@@ -1563,6 +1593,7 @@ packages:
     engines: {node: '>= 0.4.0'}
     dependencies:
       function-bind: 1.1.1
+    dev: true
 
   /html-encoding-sniffer/3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -1687,6 +1718,7 @@ packages:
     resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
+    dev: true
 
   /is-date-object/1.0.5:
     resolution: {integrity: sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==}
@@ -1861,6 +1893,7 @@ packages:
   /kleur/4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+    dev: true
 
   /levn/0.3.0:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
@@ -1922,6 +1955,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.14
+    dev: true
 
   /magic-string/0.29.0:
     resolution: {integrity: sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==}
@@ -1993,11 +2027,13 @@ packages:
 
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+    dev: true
 
   /nanoid/3.3.4:
     resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+    dev: true
 
   /natural-compare-lite/1.4.0:
     resolution: {integrity: sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==}
@@ -2143,6 +2179,7 @@ packages:
 
   /path-parse/1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+    dev: true
 
   /path-type/4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2155,6 +2192,7 @@ packages:
 
   /picocolors/1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+    dev: true
 
   /picomatch/2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
@@ -2170,6 +2208,7 @@ packages:
     resolution: {integrity: sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==}
     engines: {node: '>=14'}
     hasBin: true
+    dev: true
 
   /postcss-import/14.1.0_postcss@8.4.21:
     resolution: {integrity: sha512-flwI+Vgm4SElObFVPpTIT7SU7R3qk2L7PyduMcokiaVKuWv9d/U+Gm/QAd8NDLuykTWTkcrjOeD2Pp1rMeBTGw==}
@@ -2239,6 +2278,7 @@ packages:
       nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
+    dev: true
 
   /prelude-ls/1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
@@ -2353,6 +2393,7 @@ packages:
       is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+    dev: true
 
   /reusify/1.0.4:
     resolution: {integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==}
@@ -2379,6 +2420,7 @@ packages:
     hasBin: true
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /run-parallel/1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -2472,6 +2514,7 @@ packages:
   /source-map-js/1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /source-map/0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
@@ -2532,6 +2575,7 @@ packages:
   /supports-preserve-symlinks-flag/1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+    dev: true
 
   /svelte-check/3.0.3_pehl75e5jsy22vp33udjja4soi:
     resolution: {integrity: sha512-ByBFXo3bfHRGIsYEasHkdMhLkNleVfszX/Ns1oip58tPJlKdo5Ssr8kgVIuo5oq00hss8AIcdesuy0Xt0BcTvg==}
@@ -2567,6 +2611,7 @@ packages:
       svelte: '>=3.19.0'
     dependencies:
       svelte: 3.55.1
+    dev: true
 
   /svelte-preprocess/5.0.1_k4bhxdknaltjvjwprbm23edr5q:
     resolution: {integrity: sha512-0HXyhCoc9rsW4zGOgtInylC6qj259E1hpFnJMJWTf+aIfeqh4O/QHT31KT2hvPEqQfdjmqBR/kO2JDkkciBLrQ==}
@@ -2620,6 +2665,7 @@ packages:
   /svelte/3.55.1:
     resolution: {integrity: sha512-S+87/P0Ve67HxKkEV23iCdAh/SX1xiSfjF1HOglno/YTbSTW7RniICMCofWGdJJbdjw3S+0PfFb1JtGfTXE0oQ==}
     engines: {node: '>= 8'}
+    dev: true
 
   /symbol-tree/3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -2836,6 +2882,7 @@ packages:
       rollup: 3.17.0
     optionalDependencies:
       fsevents: 2.3.2
+    dev: true
 
   /vite/4.1.2_@types+node@18.14.0:
     resolution: {integrity: sha512-MWDb9Rfy3DI8omDQySbMK93nQqStwbsQWejXRY2EBzEWKmLAXWb1mkI9Yw2IJrc+oCvPCI1Os5xSSIBYY6DEAw==}
@@ -2880,6 +2927,7 @@ packages:
         optional: true
     dependencies:
       vite: 4.1.2
+    dev: true
 
   /vitest/0.25.8_jsdom@21.1.0:
     resolution: {integrity: sha512-X75TApG2wZTJn299E/TIYevr4E9/nBo1sUtZzn0Ci5oK8qnpZAZyhwg0qCeMSakGIWtc6oRwcQFyFfW14aOFWg==}

--- a/src/lib/utils/notion.ts
+++ b/src/lib/utils/notion.ts
@@ -1,29 +1,29 @@
-import { Client } from '@notionhq/client';
 import { NOTION_API_KEY } from '$env/static/private';
-const notion = new Client({
-	auth: NOTION_API_KEY
-});
+import { Client } from '@notionhq/client';
 
-const database = await notion.databases.query({
-	database_id: 'a448d280a2e840d6a4baa3a34fb853b4',
-	filter: {
-		or: [
-			{
-				property: 'isPublished',
-				checkbox: {
-					equals: true
+export default async function database() {
+	const notion = new Client({
+		auth: NOTION_API_KEY
+	});
+	const data = notion.databases.query({
+		database_id: 'a448d280a2e840d6a4baa3a34fb853b4',
+		filter: {
+			or: [
+				{
+					property: 'isPublished',
+					checkbox: {
+						equals: true
+					}
 				}
+			]
+		},
+		sorts: [
+			{
+				property: 'publishedAt',
+				direction: 'descending'
 			}
 		]
-	},
-	sorts: [
-		{
-			property: 'publishedAt',
-			direction: 'descending'
-		}
-	]
-});
-
-console.log(database.results[1]);
-
-export default database;
+	});
+	console.log(data);
+	return data;
+}

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,1 +1,18 @@
-import database from '../lib/utils/notion';
+import { NOTION_API_KEY } from '$env/static/private';
+import { Client } from '@notionhq/client';
+import type { PageServerLoad } from './$types';
+
+export const load = (async () => {
+	const notion = new Client({
+		auth: NOTION_API_KEY
+	});
+	const response = await notion.databases.query({
+		database_id: 'b8ec3c117d1b4677947153bbe44bd42d'
+	});
+	let data: { [key: string]: string } = {};
+
+	response.results.forEach((row: any) => {
+		data[row.properties.key.title[0].plain_text] = row.properties.value.rich_text[0].plain_text;
+	});
+	return data;
+}) satisfies PageServerLoad;

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -9,7 +9,7 @@ export const load = (async () => {
 	const response = await notion.databases.query({
 		database_id: 'b8ec3c117d1b4677947153bbe44bd42d'
 	});
-	let data: { [key: string]: string } = {};
+	const data: { [key: string]: string } = {};
 
 	response.results.forEach((row: any) => {
 		data[row.properties.key.title[0].plain_text] = row.properties.value.rich_text[0].plain_text;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,8 +1,10 @@
 <script>
 	import NormalButton from '$lib/components/uiParts/Button/normalButton.svelte';
+	export let data;
+	console.log(data.log);
 </script>
 
-<h2 class="text-center">こんばんわに！</h2>
+<h2 class="text-center">{data.greeting}</h2>
 
 <p class="h2 text-center font-serif text-2xl">うすゆきについて</p>
 <NormalButton title="もっと知る！" url="/about" bgColorVariable="blue" textColorVariable="black" />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,6 +1,6 @@
-<script>
+<script lang="ts">
 	import NormalButton from '$lib/components/uiParts/Button/normalButton.svelte';
-	export let data;
+	export let data: { [key: string]: string };
 	console.log(data.log);
 </script>
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,9 @@ const config: UserConfig = {
 		include: ['tests/unit/**/*.{test,spec}.{js,ts}'],
 		globals: true,
 		environment: 'jsdom'
+	},
+	build: {
+		target: 'esnext'
 	}
 };
 


### PR DESCRIPTION
# やったこと
es2020の仕様では
```
Top-level await is not available in the configured target environment
```
と怒られて、build時の設定で`esnext`を指定してもsvelteだと上手く動かないので、Top-level awaitしている箇所をなくした
