### PR TITLE
fix 色設定のせいで見えない絵文字を解消

### DIFF
--- a/src/lib/components/atom/text/word/WordWithEmoji.svelte
+++ b/src/lib/components/atom/text/word/WordWithEmoji.svelte
@@ -10,9 +10,9 @@ export let className: string = "";
 	<div class="flex md:justify-center items-center p-4">
 		<div class="group relative">
 			<div
-				class={`flex justify-end justify-center items-center p-2 bg-${bgColor} text-xl rounded-md md:rounded-full cursor-pointer shadow-xl hover:shadow-2xl duration-300`}
+				class={`flex justify-center items-center p-2 bg-${bgColor} text-xl rounded-md md:rounded-full cursor-pointer shadow-xl hover:shadow-2xl duration-300`}
 			>
-				<p>{emoji}</p>
+				<p class="text-white">{emoji}</p>
 			</div>
 			<div
 				class="md:invisible md:opacity-0 absolute -top-7 md:top-12 md:-left-12 z-10 w-40 flex md:justify-center group-hover:visible group-hover:opacity-100 duration-300 bg-black text-white p-2 rounded-md md:rounded-lg"


### PR DESCRIPTION
# やったこと
↓文字色が黒になってあ
<img width="1052" height="140" alt="image" src="https://github.com/user-attachments/assets/92f0f802-0ca5-4491-98b7-481fb88462de" />

# 備考

# スクリーンショット(任意)
